### PR TITLE
Container name for task, based on node config job_manager_host

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -404,7 +404,7 @@ func (n *ManuscriptNode) ProcessNewTaskCreatedLog(newTaskCreatedLog *bindings.Ch
 func (n *ManuscriptNode) ExecuteTask(taskIndex uint32, taskDetails *core.TaskDetails) error {
 	n.logger.Info("Executing task", "task index", taskIndex, "task details", taskDetails)
 
-	containerName := "chainbase_jobmanager"
+	containerName := n.jobManagerHost
 	cmd := []string{
 		"/bin/sh",
 		"-c",
@@ -549,7 +549,7 @@ func (n *ManuscriptNode) CancelTaskJob(taskIndex uint32) {
 	}
 	n.logger.Info("Task Job  is cancelling", "taskIndex", taskIndex, "JobID", jobID)
 
-	containerName := "chainbase_jobmanager"
+	containerName := n.jobManagerHost
 	cmd := []string{"flink", "cancel", jobID}
 	execConfig := dockerTypes.ExecConfig{
 		Cmd:          cmd,


### PR DESCRIPTION
Good day!

Glad to see v0.2.X as new mainline. Current PR is focused to reduce duplication of places where we specify jobmanager_host.

Current status
1. We set static jobname container name [in docker-compose.yml](https://github.com/chainbase-labs/chainbase-avs-setup/blob/main/holesky/docker-compose.yaml#L4)
2. We job_manager_host which is same as hostname (formally must be servicename) [in docker-compose.yml](https://github.com/chainbase-labs/chainbase-avs-setup/blob/main/holesky/docker-compose.yaml#L5)
3. Then we use static container name in code, where this PR is focused to change logic, as step 1

Three points where something could go wrong. So main goal to reduce config points to minimal.

My propose in PR
1. Use job_manager_host config value as variable for container_name, rather than current static value
2. Reduce one point of failure where someday we reconfigure job_manager_host

After that we only need to setup docker-compose.yml, node.yaml without braking code at all. It's more logical to attach container name to node config, rather than using static value, which can broke by docker compose, which has weak relation to node service at all.

If this PR is acceptable, my next propose will be, move jobmanagers container_name and hostname to .env, to get single point of control for job_manager_host, besides node.yaml. This is valid for docker-compose, nomad, kubernetes, and can be well documented too.